### PR TITLE
Scattercharts have been broken since 1.0.0-alpha.6

### DIFF
--- a/src/cartesian/Scatter.js
+++ b/src/cartesian/Scatter.js
@@ -124,7 +124,7 @@ class Scatter extends Component {
         axis: xAxis, ticks: xAxisTicks, bandSize: xBandSize, entry, index,
       });
       const cy = getCateCoordinateOfLine({
-        axis: yAxis, ticks: xAxisTicks, bandSize: yBandSize, entry, index,
+        axis: yAxis, ticks: yAxisTicks, bandSize: yBandSize, entry, index,
       });
       const size = z !== '-' ? zAxis.scale(z) : defaultZ;
       const radius = Math.sqrt(Math.max(size, 0) / Math.PI);


### PR DESCRIPTION
Fixing this typo fixes them. See https://github.com/recharts/recharts/commit/fe6452f0fbd75d62881a289d94a29e5f10b0b4ed#r25878004